### PR TITLE
Replace jQuery.unique with a string-compatible one

### DIFF
--- a/src/custom.js
+++ b/src/custom.js
@@ -137,7 +137,12 @@ $(function() {
             for (var i = 0; i < classes.length; i++) {
                 class_urls.push($(classes[i]).attr("href"));
             }
-            class_urls = $.unique(class_urls);
+            class_urls = class_urls.reduce(function(previousValue, currentValue) {
+                if(previousValue.indexOf(currentValue) == -1) {
+                    return previousValue.concat([currentValue]);
+                }
+                return previousValue;
+            }, new Array());
 
             var remain = class_urls.length;
             for (var j = 0; j < class_urls.length; j++) {


### PR DESCRIPTION
This PR removes duplicates of classes from 課題一覧.

`jQuery.unique` is a function to remove duplicates from an array of DOM elements. Since `class_urls` is not an array of DOM elements, it fails to remove all the duplications and displays the same homework more than once.

Thus, I replaced the function with the one that works with an array of string.