### PR TITLE
Fix bugs in FC_EasyTimetable and bbs_area

### DIFF
--- a/src/custom.js
+++ b/src/custom.js
@@ -44,6 +44,7 @@ if (getSaveData()['css'] && location.pathname != "/sfc-sfs/index.cgi") {
 }
 $(function() {
     var QUERY = parseQueryString(location.search);
+    var LANG = getParamString(QUERY, 'lang') || 'lang=ja';
     /** Lesson **/
     var Lesson = function(url, dirtyhtml) {
         var dom = $("<div/>").addClass("tmp" + Math.random()).css({
@@ -132,9 +133,9 @@ $(function() {
         return null;
     }
     var FC_EasyTimetable = function() {
-        var param_id = location.search.match("id=[a-z0-9]+")[0];
-        var param_term = $("[target=frame]").attr("href").match("term=[0-9]{4}.")[0];
-        var content = "https://vu.sfc.keio.ac.jp/sfc-sfs/sfs_class/student/plan_timetable.cgi?" + UT_getLang() + "&" + param_term + "&" + param_id;
+        var id = getParamString(QUERY, 'id');
+        var term = getParamString(parseQueryString($('iframe').attr('src')), 'term');
+        var content = "https://vu.sfc.keio.ac.jp/sfc-sfs/sfs_class/student/plan_timetable.cgi?" + mergeParamStrings([LANG, term, id]);
         $(".noticeTitle").after($('<iframe width="100%" frameborder="0" height="800" scrolling="auto" marginwidth="0" marginheight="0" align="middle"/>').attr("src", content));
         console.log(content);
     }

--- a/src/custom.js
+++ b/src/custom.js
@@ -11,6 +11,29 @@ var setSaveData = function(data) {
 setInitSaveData({
     css: true
 });
+var filterFalsy = function (e) {
+    return e
+};
+var parseQueryString = function (url) {
+    return (url.split('?')[1] || '')
+        .split('&')
+        .filter(filterFalsy)
+        .map(function (param) {
+            return param.split('=').map(decodeURIComponent)
+        })
+        .reduce(function (a, param) {
+            k = param[0];
+            v = param[1];
+           	a[k] = a[k] ? [v].concat(a[k]) : v;
+            return a;
+        }, Object.setPrototypeOf({}, null));
+};
+var getParamString = function (query, param) {
+    return query[param] && param + '=' + query[param];
+};
+var mergeParamStrings = function (params) {
+    return '?' + params.join('&')
+};
 /** CSS適用 **/
 if (getSaveData()['css'] && location.pathname != "/sfc-sfs/index.cgi") {
     $("head").append($("<link/>").attr({
@@ -20,6 +43,7 @@ if (getSaveData()['css'] && location.pathname != "/sfc-sfs/index.cgi") {
     }));
 }
 $(function() {
+    var QUERY = parseQueryString(location.search);
     /** Lesson **/
     var Lesson = function(url, dirtyhtml) {
         var dom = $("<div/>").addClass("tmp" + Math.random()).css({

--- a/src/custom.js
+++ b/src/custom.js
@@ -286,7 +286,7 @@ $(function() {
 
     /** 掲示板機能 **/
     if (location.pathname == "/sfc-sfs/sfs_class/student/s_class_top.cgi") {
-        var yc = location.href.match("yc=[2014]{4}_[0-9]+")[0];
+        var yc = getParamString(QUERY, 'yc');
         var bbsContent = $('<tr><td valign="top" align="right" bgcolor="#cbd7e4"><font color="#000000"><b>匿名掲示板<br>βテスト</b></font><span class="en"><br>Notice</span></td><td bgcolor="#cbd7e4" width="100%"><div class="bbs_area"></div><br></td></tr>');
         var hrBar = $('<tr> <th align="right"><hr noshade=""></th><td><hr noshade=""></td></tr>');
         $("b:contains(お知らせ)").parent().parent().parent().before(bbsContent);

--- a/src/custom.js
+++ b/src/custom.js
@@ -136,7 +136,9 @@ $(function() {
         var id = getParamString(QUERY, 'id');
         var term = getParamString(parseQueryString($('iframe').attr('src')), 'term');
         var content = "https://vu.sfc.keio.ac.jp/sfc-sfs/sfs_class/student/plan_timetable.cgi?" + mergeParamStrings([LANG, term, id]);
-        $(".noticeTitle").after($('<iframe width="100%" frameborder="0" height="800" scrolling="auto" marginwidth="0" marginheight="0" align="middle"/>').attr("src", content));
+        $.get(content, function (data) {
+            $('.noticeTitle').after($('<div/>').html(data))
+        });
         console.log(content);
     }
     var FC_Homework = function() {


### PR DESCRIPTION
## Problems

1. FC_EasyTimetable
![image](https://user-images.githubusercontent.com/24631178/58808417-f35f6180-8654-11e9-9f51-a53084f16a20.png)

2. bbs_area
![image](https://user-images.githubusercontent.com/24631178/58808523-26095a00-8655-11e9-908c-aabbd659d8fd.png)


## Environment
- Chrome 74

## Patch
The pull request includes several fixes in custom.js

1. FC_EasyTimetable
Maybe due to the SFS system change, `$("[target=frame]").attr("href")` will be `undefined`. Therefore, instead of regular expression, I implement functions to parse query string and get param string from query. Also, to remove the empty space made by iframe, I use a div instead.

2. bbs_area
`location.href.match("yc=[2014]{4}_[0-9]+")[0];`
This regular expression can only match the year of 2014, so I try to get the param string from query instead.